### PR TITLE
Include Page Title for InputfieldPage fields

### DIFF
--- a/ProcessVersionControl.module
+++ b/ProcessVersionControl.module
@@ -346,6 +346,16 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
 
         // render output
         $field = $this->fields->get($field_name);
+
+        if($field->labelFieldName == '.') {
+            $labelFieldFormat = $field->labelFieldFormat;
+            $labelFieldName = 'title|name';
+        } else {
+            $labelFieldFormat = '';
+            $labelFieldName = $field->labelFieldName ? $field->labelFieldName : 'title';
+            $labelFieldName .= "|name";
+        }
+
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $id = $row['id'] == $r1 ? "r1" : "r2";
             echo "<textarea id='{$id}' class='revision' data-revision='{$row['id']}'>";
@@ -354,7 +364,13 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
             } else {
                 $items = explode('|', $row['data']);
                 foreach($items as &$item) {
-                    $item = $this->pages->get((int)$item)->getMarkup($field->labelFieldFormat) . ' (' . $item . ')';
+                    $p = $this->pages->get((int)$item);
+
+                    $of = $p->of();
+                    $p->of(true);
+                    $item = $labelFieldFormat ? $p->getMarkup($labelFieldFormat) : $p->get($labelFieldName);
+                    if(!strlen($item)) $v = $p->get('name');
+                    $p->of($of);
                 }
                 echo implode(", ", $items);
             }

--- a/ProcessVersionControl.module
+++ b/ProcessVersionControl.module
@@ -345,9 +345,20 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
         $stmt->execute();
 
         // render output
+        $field = $this->fields->get($field_name);
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
             $id = $row['id'] == $r1 ? "r1" : "r2";
-            echo "<textarea id='{$id}' class='revision' data-revision='{$row['id']}'>{$row['data']}</textarea>";
+            echo "<textarea id='{$id}' class='revision' data-revision='{$row['id']}'>";
+            if($field instanceof InputfieldPage) {
+                echo $row['data'];
+            } else {
+                $items = explode('|', $row['data']);
+                foreach($items as &$item) {
+                    $item = $this->pages->get((int)$item)->getMarkup($field->labelFieldFormat) . ' (' . $item . ')';
+                }
+                echo implode(", ", $items);
+            }
+            echo "</textarea>";
         }
         ?>
         <div id='diff'></div>


### PR DESCRIPTION
Changed the diff view to include page titles for InputfieldPage fields to allow editors to easily see what has been changed.
Uses `labelFieldName` and `labelFieldFormat` to keep the output consistent with the values shown for the normal field