### PR TITLE
Fix: SQLSTATE[42000]: Syntax error or access violation

### DIFF
--- a/ProcessVersionControl.module
+++ b/ProcessVersionControl.module
@@ -240,11 +240,11 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
 
         // find values
         $stmt = $this->database->prepare("
-        SELECT r.pages_id, f.name AS field_name, r.timestamp, r.users_id, r.username, d.revisions_id, d.property, d.data
+        SELECT r.pages_id, f.name AS field_name, r.timestamp, r.users_id, r.username, d.revisions_id, MIN(DISTINCT d.property), MIN(DISTINCT d.data)
         FROM fields AS f, " . VersionControl::TABLE_REVISIONS . " AS r, " . VersionControl::TABLE_DATA . " AS d
         WHERE r.pages_id IN (" . rtrim(str_repeat('?, ', count($page_ids)), ', ') . ") AND d.revisions_id = r.id AND f.id = d.fields_id
         GROUP BY r.id, f.id
-        ORDER BY f.id, d.id DESC
+        ORDER BY f.id, MIN(DISTINCT d.id) DESC
         ");
         $stmt->execute($page_ids);
 


### PR DESCRIPTION
Your Selector is not compatible with: sql_mode=only_full_group_by

Errors:
SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #7 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'objektdatenbank.d.property' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by (in /site/modules/VersionControl/ProcessVersionControl.module line 249)

SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #8 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'objektdatenbank.d.data' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by (in /site/modules/VersionControl/ProcessVersionControl.module line 248)

SQLSTATE[42000]: Syntax error or access violation: 1055 Expression #2 of ORDER BY clause is not in GROUP BY clause and contains nonaggregated column 'objektdatenbank.d.id' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by (in /site/modules/VersionControl/ProcessVersionControl.module line 249)
