### PR TITLE
Show message in History Tab if the rendered table is empty

### DIFF
--- a/VersionControl.module
+++ b/VersionControl.module
@@ -1012,7 +1012,12 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             ++$counter;
         }
         $field = $this->modules->get("InputfieldMarkup");
-        $field->value = $table->render() . $pager;
+        $table = $table->render() . $pager;
+        if (empty($table)) {
+            $field->value = __("No history of changes found.");
+        } else {
+            $field->value = $table;
+        }
         $field->label = __("History");
         $wrapper->append($field);
 


### PR DESCRIPTION
At this moment when there are no records, the tab still shows, but seems unclickable. I've added an extra check which shows a message in case there are no records found.