### PR TITLE
Improved data handling for LanguagesPageFieldValue at module installa…

### DIFF
--- a/PageSnapshot.module
+++ b/PageSnapshot.module
@@ -246,7 +246,7 @@ class PageSnapshot extends WireData implements Module {
         }
 
         // find values
-        $where = $revision_id ? "t1.id = ? AND " : "";
+        $where = $revision_id ? "t1.id <= ? AND " : "";
         $stmt = $this->database->prepare($sql = "
         SELECT t1.pages_id, t1.id AS revision, t2.fields_id, t2.property, t2.data
         FROM (

--- a/PageSnapshot.module
+++ b/PageSnapshot.module
@@ -258,6 +258,7 @@ class PageSnapshot extends WireData implements Module {
         INNER JOIN " . VersionControl::TABLE_DATA . " AS t2
         ON t2.revisions_id = t1.id AND t2.fields_id = t1.fields_id
         GROUP BY t1.pages_id, t2.fields_id, t2.property
+        ORDER BY revision ASC
         ");
         $input_parameters = $where ? array($revision_id) : array();
         $input_parameters = array_merge($input_parameters, $page_ids);

--- a/ProcessVersionControl.module
+++ b/ProcessVersionControl.module
@@ -240,11 +240,11 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
 
         // find values
         $stmt = $this->database->prepare("
-        SELECT r.pages_id, f.name AS field_name, r.timestamp, r.users_id, r.username, d.revisions_id, d.property, d.data
+        SELECT r.pages_id, f.name AS field_name, r.timestamp, r.users_id, r.username, d.revisions_id, MIN(DISTINCT d.property), MIN(DISTINCT d.data)
         FROM fields AS f, " . VersionControl::TABLE_REVISIONS . " AS r, " . VersionControl::TABLE_DATA . " AS d
         WHERE r.pages_id IN (" . rtrim(str_repeat('?, ', count($page_ids)), ', ') . ") AND d.revisions_id = r.id AND f.id = d.fields_id
         GROUP BY r.id, f.id
-        ORDER BY f.id, d.id DESC
+        ORDER BY f.id, MIN(DISTINCT d.id) DESC
         ");
         $stmt->execute($page_ids);
 

--- a/ProcessVersionControl.module
+++ b/ProcessVersionControl.module
@@ -240,7 +240,7 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
 
         // find values
         $stmt = $this->database->prepare("
-        SELECT r.pages_id, f.name AS field_name, r.timestamp, r.users_id, r.username, d.revisions_id, MIN(DISTINCT d.property), MIN(DISTINCT d.data)
+        SELECT r.pages_id, f.name AS field_name, r.timestamp, r.users_id, r.username, d.revisions_id, GROUP_CONCAT(d.property) AS propertylist, MIN(DISTINCT d.data)
         FROM fields AS f, " . VersionControl::TABLE_REVISIONS . " AS r, " . VersionControl::TABLE_DATA . " AS d
         WHERE r.pages_id IN (" . rtrim(str_repeat('?, ', count($page_ids)), ', ') . ") AND d.revisions_id = r.id AND f.id = d.fields_id
         GROUP BY r.id, f.id
@@ -265,6 +265,7 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
                 'username' => isset($row['username']) ? $this->sanitizer->name($row['username']) : null,
                 'revision' => isset($row['revisions_id']) ? $row['revisions_id'] : null,
                 'date' => isset($row['timestamp']) ? $row['timestamp'] : null,
+                'propertylist' => isset($row['propertylist']) ? $row['propertylist'] : null,
                 'data' => isset($row['data']) ? $row['data'] : null
             );
             if (isset($row['users_id']) && $user = $this->users->get((int) $row['users_id'])) {
@@ -356,11 +357,20 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
         $r2 = (int) $r2;
         if (!$r1 || !$r2) throw new WireException("Revisions need to be provided in following format: 123:124");
 
+        $data = array();
+        $propertyselect = null;
+        $propertywhere = null;
+        if ($this->input->get->property!='undefined') {
+            $propertyselect = ', d.property';
+            $propertywhere = ' AND d.property=\''.$this->input->get->property.'\'';
+            $data = array();
+
+        }
         // find values
         $stmt = $this->database->prepare("
-        SELECT r.id, d.data
+        SELECT r.id, d.data$propertyselect
         FROM fields AS f, " . VersionControl::TABLE_REVISIONS . " AS r, " . VersionControl::TABLE_DATA . " AS d
-        WHERE r.id IN(:r1, :r2) AND d.revisions_id = r.id AND f.name = :field_name AND d.fields_id = f.id
+        WHERE r.id IN(:r1, :r2) AND d.revisions_id = r.id AND f.name = :field_name AND d.fields_id = f.id$propertywhere
         ORDER BY r.id ASC
         LIMIT 2
         ");
@@ -370,8 +380,9 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
         $stmt->execute();
 
         // render output
-        $data = array();
+        $rowcount = 0;
         while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            $rowcount++;
             $id = $row['id'] == $r1 ? "r1" : "r2";
             if ($field->type == "FieldtypePage") {
                 $data[$id] = array();
@@ -398,6 +409,10 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
             } else {
                 echo "<textarea id='{$id}' class='revision' data-revision='{$row['id']}'>{$row['data']}</textarea>";
             }
+        }
+        // if the query only returns one revision, then we add a warning for the missing rivision (r1) - this is only a tempoary solution 
+        if ($rowcount==1) {
+            echo "<textarea id='r1' class='revision' data-revision='{$r1}'>" . __("Active revision not defined in this language") . "</textarea>";
         }
         if ($field->type == "FieldtypePage") {
             // in the case of a Page field comparing strings makes little sense;
@@ -662,12 +677,32 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
                         if ($user->id) $user_name = wirePopulateStringTags($this->user_name_format, $user);
                     }
                     if (!$user_name) $user_name = $row['username'];
-                    $markup .= "<li><a"
-                             . " data-revision='{$row['revision']}'"
-                             . " data-date='{$row['date']}'"
-                             . " href='#'>"
-                             . "<span class='date'>{$row['date']}</span> <span class='user'>{$user_name}</span>"
-                             . "</a></li>";
+                    $langs = null;
+                    if (isset($row['propertylist'])  and ($row['propertylist']!='data')) {
+                        $languages = wire('languages');
+                        if (isset($languages)) {
+                            $propertylist = array_flip(explode(',',$row['propertylist']));
+                            $lids = array();
+                            $markup .= "<li><span class='date'>{$row['date']}</span> ";
+                            foreach ($languages as $language) {
+                                $propertyidx = 'data'.$language->id;
+                                $markup .= isset($propertylist[$propertyidx]) 
+                                    ? "<a data-revision='{$row['revision']}'"
+                                        . " data-date='{$row['date']}'"
+                                        . " data-property='$propertyidx'"
+                                        . " href='#'>"
+                                        . "<span class='language'>$language->title</span></a> "
+                                    : "<span class='language'>&nbsp;</span> ";
+                            }
+                            $markup .= "<span class='user'>{$user_name}</span></li>";
+                        }
+                    } else
+                        $markup .= "<li><a"
+                                 . " data-revision='{$row['revision']}'"
+                                 . " data-date='{$row['date']}'"
+                                 . " href='#'>"
+                                 . "<span class='date'>{$row['date']}</span> <span class='user'>{$user_name}</span>"
+                                 . "</a></li>";
                 }
                 $markup .= "</ul>";
             } else {

--- a/ProcessVersionControl.module
+++ b/ProcessVersionControl.module
@@ -4,12 +4,12 @@
  * Process Version Control
  *
  * This module acts as an interface for Version Control module by generating
- * markup it requires based on various GET params, making itself available
- * via ProcessWire Admin page.
+ * markup it requires based on GET params and making itself available via a
+ * ProcessWire Admin page.
  *
- * For more details, see the README.md file distributed with this module.
+ * For more details see the README.md file distributed with this module.
  *
- * @copyright Copyright (c) 2013-2016, Teppo Koivula
+ * @copyright 2013-2016 Teppo Koivula
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License, version 2
  */
 class ProcessVersionControl extends Process implements ConfigurableModule {
@@ -25,7 +25,7 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
             'summary' => 'Provides the interface required by Version Control.',
             'href' => 'http://modules.processwire.com/modules/version-control/',
             'author' => 'Teppo Koivula',
-            'version' => '1.2.3',
+            'version' => '1.2.4',
             'singular' => true,
             'autoload' => false,
             'permission' => 'version-control',
@@ -53,6 +53,7 @@ class ProcessVersionControl extends Process implements ConfigurableModule {
     /**
      * Name of admin page created and used by this module
      * 
+     * @var string
      */
     const PAGE_NAME = 'version-control';
 

--- a/VersionControl.css
+++ b/VersionControl.css
@@ -65,16 +65,26 @@ textarea.version_control_filedata {
 }
 
 .field-revisions a {
-    margin: 0 5px;
-    padding: 5px 4px;
+    margin: 0 0px;
+    padding: 5px 0px;
     white-space: nowrap;
     font-weight: normal;
     display: inline-block;
     text-shadow: 0 1px 0 rgba(255,255,255,0.5);
 }
 
-.field-revisions a .user {
-    padding-left: 2em;
+.field-revisions .user {
+    padding-left: 0.2em;
+}
+
+.field-revisions .date {
+    padding-left: 0.0em;
+}
+
+.field-revisions .language {
+    display: inline-block; 
+    width: 60px;
+    padding-left: 0.0em;
 }
 
 .compare-revisions > a.diff-trigger::before {
@@ -102,7 +112,7 @@ textarea.version_control_filedata {
 .field-revisions .ui-state-active {
     border: 0;
     cursor: default;
-    padding: 5px 4px;
+    padding: 5px 0px;
 }
 
 body.template-admin .field-revisions .ui-state-active {

--- a/VersionControl.js
+++ b/VersionControl.js
@@ -238,7 +238,8 @@ $(function() {
                     var field = $(this).parents('.field-revisions:first').data('field');
                     var r1 = $(this).parents('.field-revisions:first').find('.ui-state-active').data('revision');
                     var r2 = $(this).data('revision');
-                    var href = moduleConfig.processPage+'diff/?revisions='+r1+':'+r2+'&field='+field;
+                    var property = $(this).data('property');
+                    var href = moduleConfig.processPage+'diff/?revisions='+r1+':'+r2+'&field='+field+'&property='+property;
                     var label = moduleConfig.i18n.compareWithCurrent;
                     $(this).before('<div class="compare-revisions"><a class="diff-trigger" href="'+href+'">'+label+'</a></div>');
                 }

--- a/VersionControl.module
+++ b/VersionControl.module
@@ -730,7 +730,24 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
                         }
                         if (!count($data_array)) $data_array['0.data'] = null;
                     } else if ($data instanceof LanguagesPageFieldValue) {
-                        foreach ($data->getChanges() as $key) {
+                        // There are two cases to be considered
+                        // 1) We read the data from the fields of a page already existing at module installation
+                        // 2) We read the data from a field modified after the module was installed
+                        if ($object instanceof Page) {
+                            // 1) Page/fields already exist at time of module installation
+                            // we need to save the corresponding value for each language installed as a reference for 
+                            // future changes
+                            $data_keys = array();
+                            foreach (wire('languages') as $language) {
+                                $data_keys[] = 'data'.$language->id;
+                            }
+                        } else {
+                            // 2) We need to save the new values of fields modified on the page
+                            // The function getChanges() prefectly returns these values 
+                            $data_keys = $data->getChanges(); 
+                        }
+                        // loop over the page/field data for each of the keys found above
+                        foreach ($data_keys as $key) {
                             if ($key == 'data') continue;
                             $data_array[$key] = $data->getLanguageValue(str_replace('data', '', $key));
                         }

--- a/VersionControl.module
+++ b/VersionControl.module
@@ -3,15 +3,16 @@
 /**
  * Version Control
  * 
- * Together with the accompanied Process module, Process Version Control, this
- * module makes it possible to review and restore earlier values for specific
- * fields, and even entire pages.
+ * This module makes it possible to store, review, and restore earlier values
+ * of specific fields or even entire pages. Changes are automatically tracked
+ * for enabled fields and templates and earlier versions can be reviews and
+ * restored either via Page Edit GUI or the API.
  * 
- * Behind the scenes this hooks provided by ProcessWire are used to capture any
- * changes to individual fields and store them in a series of database tables,
- * along with required metadata, such as revision numbers.
+ * Behind the scenes the hooks provided by ProcessWire are used to capture any
+ * changes to individual fields and store them in a series of custom database
+ * tables, along with required metadata, such as a running revision number.
  * 
- * @copyright 2013-2016 Teppo Koivula
+ * @copyright 2013-2017 Teppo Koivula
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License, version 2
  * @todo regenerate data when fields are added to a tracked Template/Fieldgroup (see ProcessWire issue #1247)
  */
@@ -28,7 +29,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             'summary' => 'Version control features for page content.',
             'href' => 'http://modules.processwire.com/modules/version-control/',
             'author' => 'Teppo Koivula',
-            'version' => '1.2.8',
+            'version' => '1.2.9',
             'singular' => true,
             'autoload' => true,
             'installs' => array(
@@ -358,7 +359,6 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             // add hooks that add additional scripts, styles and markup
             $this->addHookAfter('ProcessPageEdit::execute', $this, 'inject');
             $this->addhookAfter('ProcessPageEdit::buildForm', $this, 'buildFormHistory');
-            $this->addHookAfter('ProcessPageEdit::getTabs', $this, 'addTabHistory');
             // add hooks that alter image and file inputfield output on the fly
             $this->addHookBefore('InputfieldImage::renderItem', $this, 'captureHash');
             $this->addHookBefore('InputfieldFile::renderItem', $this, 'captureHash');
@@ -975,17 +975,24 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
         // make sure that current user has version-control permission
         if (!$this->user->hasPermission('version-control')) return;
 
-        // define start and limit
+        // fetch the page being edited
+        $form = $event->return;
+        $page = $this->pages->get((int) $form->get('id')->value);
+        
+        // make sure that version control is enabled for the template of the
+        // page being edited
+        if (!$this->isEnabledTemplate($page->template)) return;
+        
+        // fetch history data for the page being edited
         $limit = 25;
         $start = $this->input->get->page ? ($this->input->get->page-1)*$limit : 0;
-
-        // fetch page history
-        $form = $event->return;
-        $page = $this->pages->get($form->get('id')->value);
         $data = $this->getHistory($page, $start, $limit, array(
             'users_id' => $this->input->get->users_id,
         ));
         if (!$data) return;
+        
+        // define history tab position
+        $this->addHookAfter('ProcessPageEdit::getTabs', $this, 'addTabHistory');
         
         // pager markup
         $pager = "";

--- a/VersionControl.module
+++ b/VersionControl.module
@@ -28,7 +28,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             'summary' => 'Version control features for page content.',
             'href' => 'http://modules.processwire.com/modules/version-control/',
             'author' => 'Teppo Koivula',
-            'version' => '1.2.7',
+            'version' => '1.2.8',
             'singular' => true,
             'autoload' => true,
             'installs' => array(
@@ -841,9 +841,16 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
                     } else {
                         if (!is_dir($dir)) wireMkdir($dir . "variations", true);
                         copy($data['original_filename'], $file);
-                        $finfo = finfo_open(FILEINFO_MIME_TYPE);
-                        $mime_type = finfo_file($finfo, $file);
-                        finfo_close($finfo);
+                        $mime_type = '';
+                        if ($this->use_fileinfo) {
+                            // PECL fileinfo extension is not enabled by
+                            // default in Windows, so we check first
+                            $finfo = finfo_open(FILEINFO_MIME_TYPE);
+                            $mime_type = finfo_file($finfo, $file);
+                            finfo_close($finfo);
+                        } else if ($this->use_mime_content_type) {
+                            $mime_type = mime_content_type($file);
+                        }
                         $size = filesize($file);
                         if (!$size) $size = 0;
                         $stmt = $this->database->prepare("INSERT INTO " . self::TABLE_FILES . " (filename, mime_type, size) VALUES (:filename, :mime_type, :size)");
@@ -1740,11 +1747,12 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
     }
 
     /**
-     * Custom getter mainly for path and url variables
-     *
-     * We're using files directory of our process module as file storage; fetch
-     * and cache locally it's path and URL. If directory doesn't exist, create.
-     * If key is unrecognized, pass the request to parent class.
+     * Custom getter for caching runtime variables. If a key is unrecognized,
+     * we pass the request to the parent class.
+     * 
+     * We're using the files directory of our process module as file storage;
+     * main feature of this method is fetching and caching it's path and URL.
+     * If this directory doesn't exist, we create it when first requested.
      * 
      * @param string $key
      * @return mixed
@@ -1762,6 +1770,16 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
                 }
             }
             return isset($this->data[$key]) ? $this->data[$key] : null;
+        } else if ($key == "use_fileinfo") {
+            if (!array_key_exists($key, $this->data)) {
+                $this->data[$key] = extension_loaded('fileinfo') && function_exists('finfo_open');
+            }
+            return $this->data[$key];
+        } else if ($key == "use_mime_content_type") {
+            if (!array_key_exists($key, $this->data)) {
+                $this->data[$key] = function_exists('mime_content_type');
+            }
+            return $this->data[$key];
         }
         return parent::__get($key);
     }

--- a/VersionControl.module
+++ b/VersionControl.module
@@ -1012,7 +1012,12 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             ++$counter;
         }
         $field = $this->modules->get("InputfieldMarkup");
-        $field->value = $table->render() . $pager;
+        $table = $table->render() . $pager;
+        if (empty($table)) {
+            $field->value = __("No history of changes found.");
+        } else {
+            $field->value = $table;
+        }
         $field->label = __("History");
         $wrapper->append($field);
 

--- a/VersionControl.module
+++ b/VersionControl.module
@@ -2,14 +2,16 @@
 
 /**
  * Version Control
- *
- * This module uses hooks provided by ProcessWire to catch page edits and stores
- * history data in a series of custom database tables, so that it can be later
- * retrieved, reviewed, and restored.
  * 
- * For more details, see the README.md file distributed with this module.
- *
- * @copyright Copyright (c) 2013-2016, Teppo Koivula
+ * Together with the accompanied Process module, Process Version Control, this
+ * module makes it possible to review and restore earlier values for specific
+ * fields, and even entire pages.
+ * 
+ * Behind the scenes this hooks provided by ProcessWire are used to capture any
+ * changes to individual fields and store them in a series of database tables,
+ * along with required metadata, such as revision numbers.
+ * 
+ * @copyright 2013-2016 Teppo Koivula
  * @license http://www.gnu.org/licenses/gpl-2.0.txt GNU General Public License, version 2
  * @todo regenerate data when fields are added to a tracked Template/Fieldgroup (see ProcessWire issue #1247)
  */
@@ -26,7 +28,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             'summary' => 'Version control features for page content.',
             'href' => 'http://modules.processwire.com/modules/version-control/',
             'author' => 'Teppo Koivula',
-            'version' => '1.2.6',
+            'version' => '1.2.7',
             'singular' => true,
             'autoload' => true,
             'installs' => array(
@@ -83,44 +85,65 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
     
     /**
      * Container for field data
-     *
+     * 
+     * @var array
      */
     protected $page_data = array();
 
     /**
      * Container for local variables
-     *
+     * 
+     * @var array
      */
     protected $data = array();
 
     /**
      * Container for hash format filenames within image inputfields
-     *
+     * 
+     * @var array
      */
     protected $hash_map = array();
 
     /**
      * Container for runtime user information cache
-     *
+     * 
+     * @var array
      */
     protected $users_cache = array();
 
     /**
-     * Names of database tables used by this module
-     *
-     * Revisions table handles system-wide revision numbers and stores dates,
-     * user and page id's etc. (metadata) while data table stores actual data
-     * (content).
+     * Name of the revisions database table
      * 
-     * Files table stores data for individual files and data files junction
-     * table connects files with data. Separate file tables make tasks such
-     * as mime type checking, fetching file sizes and hashes etc. fast and
-     * also make it easier and more efficient to clean up orphaned files.
+     * Revisions table keeps track of revision numbers, which are system wide,
+     * and stores important metadata, such as dates, user ID's, and page ID's.
      * 
+     * @var string
      */
     const TABLE_REVISIONS = 'version_control__revisions';
+    
+    /**
+     * Name of the database table containing actual field values
+     * 
+     * @var string
+     */
     const TABLE_DATA = 'version_control__data';
+    
+    /**
+     * Name of the databae table containing metadata for stored files
+     * 
+     * Having file metadata stored in the database makes tasks such as mime
+     * type checking and fetching file sizes and file hashes fast. Another
+     * benefit is easier and more efficient cleanup for orphaned files.
+     * 
+     * @var string
+     */
     const TABLE_FILES = 'version_control__files';
+    
+    /**
+     * Name of the database table connecting file metadata with field values
+     * 
+     * @var string
+     */
     const TABLE_DATA_FILES = 'version_control__data_files';
 
     /**

--- a/VersionControl.module
+++ b/VersionControl.module
@@ -26,7 +26,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             'summary' => 'Version control features for page content.',
             'href' => 'http://modules.processwire.com/modules/version-control/',
             'author' => 'Teppo Koivula',
-            'version' => '1.2.5',
+            'version' => '1.2.6',
             'singular' => true,
             'autoload' => true,
             'installs' => array(
@@ -173,6 +173,8 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
         if (isset($data['enable_all_templates']) && $data['enable_all_templates']) {
             $field->collapsed = Inputfield::collapsedLocked;
             $field->notes = __("This setting has no effect because version control is currently enabled for all templates via Advanced Settings.");
+        } else {
+            $field->notes = __("Removing a template from here will also remove any data stored for it.");
         }
         foreach (wire('templates')->getAll() as $key => $template) {
             if ($template->name != "language") $field->addOption($key, $template);
@@ -184,7 +186,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
         $field = $modules->get("InputfieldAsmSelect");
         $field->name = "enabled_fields";
         $field->label = __("Enable version control for these fields");
-        $field->notes = __("Only fields of compatible fieldtypes can be selected. If no fields are selected, all fields of compatible fieldtypes are considered enabled.");
+        $field->notes = __("Only fields of compatible fieldtypes can be selected. If no fields are selected, all fields of compatible fieldtypes are considered enabled. Removing a field from here will also remove any data stored for it.");
         $field->icon = "file-text-o";
         $types = implode($data['compatible_fieldtypes'], "|");
         $field->addOptions(wire('fields')->find("type=$types")->getArray());
@@ -1496,7 +1498,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
     }
 
     /**
-     * Regenerate data when enabled templates change
+     * Regenerate data when enabled templates and/or fields change
      *
      * @param HookEvent $event
      */
@@ -1505,7 +1507,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
         // this only applies to settings of current module
         if ($event->arguments[0] !== $this->className()) return;
 
-        // find out which templates are going to be enabled
+        // find out which new templates have been enabled
         $new_templates = $event->arguments[1]['enabled_templates'];
         if ($event->arguments[1]['enable_all_templates']) {
             $new_templates = array();
@@ -1514,7 +1516,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             }
         }
 
-        // find out which templates are currently enabled
+        // find out which templates were already enabled
         $old_templates = $this->enabled_templates;
         if ($this->enable_all_templates) {
             $old_templates = array();
@@ -1523,17 +1525,60 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             }
         }
         
-        // make sure that enabled fields are up to date
-        // @todo regenerate data for enabled and/or disabled fields
-        $this->enabled_fields = $event->arguments[1]['enabled_fields'];
+        // fetch a list of enabled fields (old and new) plus all fields in case
+        // that no fields are enabled (which means that all fields are enabled)
+        $new_fields = $event->arguments[1]['enabled_fields'];
+        $old_fields = $this->enabled_fields;
+        $all_fields = array();
+        $all_new_fields = array();
+        $all_old_fields = array();
+        if (!$new_fields && $old_fields || $new_fields && !$old_fields) {
+            // as a minor optimization if both are undefined we never come this
+            // far since there have obviously been no changes to enabled fields
+            foreach ($this->templates->find('id=' . implode('|', array_unique(array_merge($old_templates, $new_templates)))) as $template) {
+                foreach ($template->fields as $field) {
+                    if (in_array($field->type, $this->compatible_fieldtypes)) {
+                        if (!in_array($field->id, $all_fields)) {
+                            $all_fields[] = $field->id;
+                            if (in_array($template->id, $new_templates)) {
+                                $all_new_fields[] = $field->id;
+                            }
+                            if (in_array($template->id, $old_templates)) {
+                                $all_old_fields[] = $field->id;
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-        // find out which (if any) templates were added and populate data
-        $added_templates = array_diff($new_templates, $old_templates);
-        if (count($added_templates)) {
+        // make sure that enabled fields are up to date
+        $this->enabled_fields = $new_fields;
+
+        // find out which (if any) templates were added and need regenerating
+        $regenerate_templates = array_diff($new_templates, $old_templates);
+        
+        // fetch a list of templates containing at least one newly enabled field
+        $added_fields = array_diff($new_fields ?: $all_new_fields, $old_fields ?: $all_old_fields);
+        if ($added_fields) {
+            foreach ($new_templates as $template) {
+                if (in_array($template, $regenerate_templates)) continue;
+                $template = $this->templates->get((int) $template);
+                foreach ($added_fields as $field) {
+                    if ($template->hasField((int) $field)) {
+                        $regenerate_templates[] = $template->id;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // populate new data
+        if ($regenerate_templates) {
             $cache_items = 0;
-            foreach ($added_templates as $template) {
+            foreach ($regenerate_templates as $template) {
                 $count = 0;
-                $template = wire('templates')->get($template);
+                $template = $this->templates->get((int) $template);
                 foreach ($this->pages->find("template={$template}, include=all") as $page) {
                     $this->gather($page);
                     $this->insert($page);
@@ -1553,17 +1598,40 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
 
         // find out which (if any) templates were removed and cleanup data
         $removed_templates = array_diff($old_templates, $new_templates);
-        if (count($removed_templates)) {
+        if ($removed_templates) {
             $t1 = self::TABLE_REVISIONS;
             $t2 = self::TABLE_DATA;
             foreach ($removed_templates as $template) {
-                $template = wire('templates')->get($template);
+                $template = $this->templates->get((int) $template);
                 $page_ids = array_values($this->pages->find("template={$template}, include=all")->getArray());
                 if ($page_count = count($page_ids)) {
                     $stmt = $this->database->prepare("DELETE $t1, $t2 FROM $t1, $t2 WHERE $t1.pages_id IN (" . rtrim(str_repeat('?, ', $page_count), ', ') . ") AND $t2.revisions_id = $t1.id");
                     $stmt->execute($page_ids);
                     $this->cleanupFiles();
                     $this->message(sprintf(_n("Removed stored data for %d page using template %s", "Removed stored data for %d pages using template %s", $page_count), $page_count, $template));
+                }
+            }
+        }
+        
+        // find out which (if any) fields were removed and cleanup data
+        if ($new_fields) {
+            // note that if we no longer specify enabled fields and thus all
+            // fields are now enabled, there's no need to clean up anything
+            $removed_fields = array_diff($old_fields ?: $all_old_fields, $new_fields ?: $all_new_fields);
+            if ($removed_fields) {
+                foreach ($removed_fields as $fields_id) {
+                    if ((int) $fields_id == $fields_id) {
+                        $field = $this->fields->get($fields_id);
+                        if ($field instanceof Field) {
+                            // if field doesn't exist this shouldn't be reached;
+                            // data for removed fields is cleaned up elsewhere
+                            $stmt = $this->database->prepare("DELETE FROM " . self::TABLE_DATA . " WHERE fields_id = :fields_id");
+                            $stmt->bindValue(':fields_id', $fields_id, PDO::PARAM_INT);
+                            $stmt->execute();
+                            $this->cleanupFiles();
+                            $this->message(sprintf(__("Removed stored data for field %s"), $field->name));
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
The current version does not seem to include fields of class "LanguagesPageFieldValue"(like TextAreaLanguage or TextLanguage") at the initial creation of the database table "version_control_data". The revisions are stored in "version_control_revision" but the entries for the unchanged, original data field is not included in the table "version_control_data".
The changes in the file "VersionControl.module" try to address this issue. By replacing the function _LanguagesPageFieldValue::getChanges_ for the case of the original database initialisation. _LanguagesPageFieldValue::getChanges_ works perfectly fine for changes of fields submitted in later revisions of the pages.  