### PR TITLE
Restoring revisions

### DIFF
--- a/PageSnapshot.module
+++ b/PageSnapshot.module
@@ -246,7 +246,7 @@ class PageSnapshot extends WireData implements Module {
         }
 
         // find values
-        $where = $revision_id ? "t1.id = ? AND " : "";
+        $where = $revision_id ? "t1.id <= ? AND " : "";
         $stmt = $this->database->prepare($sql = "
         SELECT t1.pages_id, t1.id AS revision, t2.fields_id, t2.property, t2.data
         FROM (

--- a/PageSnapshot.module
+++ b/PageSnapshot.module
@@ -258,6 +258,7 @@ class PageSnapshot extends WireData implements Module {
         INNER JOIN " . VersionControl::TABLE_DATA . " AS t2
         ON t2.revisions_id = t1.id AND t2.fields_id = t1.fields_id
         GROUP BY t1.pages_id, t2.fields_id, t2.property
+        ORDER BY revision ASC
         ");
         $input_parameters = $where ? array($revision_id) : array();
         $input_parameters = array_merge($input_parameters, $page_ids);


### PR DESCRIPTION
This patch addresses the issue "Restoring revisions" raised [here](https://github.com/teppokoivula/VersionControl/issues/14).

It makes two changes to the query looking up the revision history to restore the changes applied to a page:

1. All revisions up the required revision are listed.
2. The revisions need to be sorted in ascending order to make sure that the changes are applied in the correct timely order.

This patch has been tested on my PW version 3.0.59 dev. test installation and seems to work with fields of type "Text", "TextLanguage" and "Repeater". Others I have not explicitly tested.