### PR TITLE
Add an option to only track changes to published pages

### DIFF
--- a/VersionControl.module
+++ b/VersionControl.module
@@ -47,6 +47,7 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
         'enabled_templates' => [],
         'enable_all_templates' => false,
         'enable_locked_fields' => false,
+        'only_track_published' => false,
     ];
 
     /**
@@ -358,6 +359,21 @@ class VersionControl extends WireData implements Module, ConfigurableModule {
             $template = $page->getForPage()->template;
         }
         if (!$force && !$this->isEnabledTemplate($template)) return;
+
+        if ($this->only_track_published) {
+            $prevStatus = $page->statusPrevious ?: $page->status;
+            if ($page->isUnpublished() && ($prevStatus & Page::statusUnpublished)) {
+                //Page is unpublished and remains unpublished. Don’t track changes.
+                return;
+            } else if ($page->isUnpublished() && !($prevStatus & Page::statusUnpublished)) {
+                //Page is being unpublished. Don’t track changes.
+                return;
+            }
+            else if (!$page->isUnpublished() && ($prevStatus & Page::statusUnpublished)) {
+                //Page is being published. Track the current state of all enabled fields.
+                $force = true;
+            }
+        }
 
         if ($force || $page->isChanged()) {
             foreach ($page->template->fields as $page_field) {

--- a/lib/ModuleConfig.php
+++ b/lib/ModuleConfig.php
@@ -83,6 +83,14 @@ class ModuleConfig extends \ProcessWire\Wire {
         $fieldset->add($field);
         $field->attr('checked', isset($data['enable_locked_fields']) && $data['enable_locked_fields']);
 
+        // enable version control only for published pages?
+        $field = $modules->get("InputfieldCheckbox");
+        $field->name = "only_track_published";
+        $field->label = $this->_("Enable version control only for published pages");
+        $field->notes = $this->_("If checked, changes will only be tracked for published pages. When a page is first published, all enabled fields will be tracked to store their original state, even if they were not changed.");
+        $fieldset->add($field);
+        $field->attr('checked', isset($data['only_track_published']) && $data['only_track_published']);
+
         // display config options from companion modules
         $ext_data = [
             'p' => ['ProcessVersionControl', 'VersionControl\ProcessModuleConfig'],


### PR DESCRIPTION
Hi, thanks for this module, it’s great!

I have a need to keep my edits off the record while pages are still in “draft mode”, so I added this tiny feature. I’ve tested it successfully on some simple pages that I will deal with, but nothing complicated like File fields or Repeaters. My changes don’t touch any of the inner workings of the change tracking, though.

If you hate this or just don’t want to support it or it clashes with your plans otherwise, I understand perfectly :) Maybe you have some ideas on how to accomplish something like this without modding the module directly?

Thanks!